### PR TITLE
fix(image): add node_modules/.bin to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ RUN apk --update add git openssh && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
 
+WORKDIR /opt
+ENV PATH="/opt/node_modules/.bin:${PATH}"
+
 COPY package.json .
 COPY yarn.lock .
 RUN yarn --prod && \
@@ -11,5 +14,5 @@ RUN yarn --prod && \
     yarn autoclean --force && \
     rm package.json yarn.lock .yarnclean
 
-ENTRYPOINT ["node_modules/.bin/semantic-release"]
+ENTRYPOINT ["semantic-release"]
 CMD ["--help"]


### PR DESCRIPTION
After moving to having a `package.json` to control which version of
`semantic-release` should be installed, using `node_modules/.bin`
directly as the entry point breaks any attempt to run it on a different
workdir. Duh!